### PR TITLE
support new zaid for metastable nuclides

### DIFF
--- a/nuclide_data.py
+++ b/nuclide_data.py
@@ -434,10 +434,14 @@ class Nuclide:
                     else: # assume it is a ZAID string
                         self.Z, self.A = zaid2za(nuc_id)
         
-        # Metastable can be specified by either E or metastable flag.
+        # Metastable can be specified by either E, metastable flag, or A > 400.
         #  If flag is given but E is not, then set E to inf as
         #  an indication that it is not stable, but that the exact
         #  E value isn't given.
+        if self.A > 400:
+            metastable = True
+            self.A -= 400
+
         if metastable and E==0.:
             E = np.inf
 
@@ -465,8 +469,11 @@ class Nuclide:
         except:
             warnings.warn("nuclide {} not on ENDFB-VII.1 neutron library".format(self))
 
-    def zaid(self):
-        return self.Z*1000 + self.A
+    def zaid(self, alternate=False):
+        if self.metastable and alternate:
+            return self.Z*1000 + self.A + 400
+        else:
+            return self.Z*1000 + self.A
 
     def decay_const(self):
         return return_nominal_value(self.Z, self.A, self.E, 'lambda')

--- a/test_nuclide_data.py
+++ b/test_nuclide_data.py
@@ -212,6 +212,18 @@ class TestNuclideData(unittest.TestCase):
         assert nuclide.metastable == True
 
 
+    def test_Nuclide_class_init_with_alternate_metastable(self):
+
+        alternate_zaid = nuclide_data.Nuclide('Li6').zaid() + 400
+        nuclide = nuclide_data.Nuclide(alternate_zaid)
+
+        assert nuclide.Z == 3
+        assert nuclide.A == 6
+        assert nuclide.element == 'Li'
+        assert nuclide.metastable == True
+        assert nuclide.zaid() == 3006
+        assert nuclide.zaid(alternate=True) == 3406
+
 
     def test_Nuclide_class_MAT(self):
         """Does Nuclide class correctly set MAT?"""


### PR DESCRIPTION
There's a new convention for supporting ZAID's that indicate a metastable state. Basically you add 400 to the mass number to indicate a metastable isomer. Technically, the convention supports multiple isomers by adding 100 for each level, but I don't see a reason to implement that because the energy is already stored in the Nuclide class.

I implemented this both when initializing the class with a ZAID as well as the class method that returns a ZAID. The way I did it, the Nuclide.zaid() function needs an argument to return the "alternate" ZAID, that way the original behavior is unchanged. Also added some unit tests.

Here's a reference for the convention:
https://mcnp.lanl.gov/pdf_files/la-ur-12-22033.pdf